### PR TITLE
Add swap processing for supiType IMSI

### DIFF
--- a/suci/toSupi.go
+++ b/suci/toSupi.go
@@ -137,6 +137,19 @@ func swapNibbles(input []byte) []byte {
 	return output
 }
 
+func calcSchemeResult(decryptPlainText []byte, supiType string) string {
+	var schemeResult string
+	if supiType == typeIMSI {
+		schemeResult = hex.EncodeToString(swapNibbles(decryptPlainText))
+		if schemeResult[len(schemeResult)-1] == 'f' {
+			schemeResult = schemeResult[:len(schemeResult)-1]
+		}
+	} else {
+		schemeResult = hex.EncodeToString(decryptPlainText)
+	}
+	return schemeResult
+}
+
 func profileA(input, supiType string) (string, error) {
 	logger.UeauLog.Infoln("SuciToSupi Profile A")
 	s, hexDecodeErr := hex.DecodeString(input)
@@ -190,17 +203,7 @@ func profileA(input, supiType string) (string, error) {
 	}
 
 	decryptPlainText := Aes128ctr(decryptCipherText, decryptEncKey, decryptIcb)
-
-	var schemeResult string
-	if supiType == typeIMSI {
-		schemeResult = hex.EncodeToString(swapNibbles(decryptPlainText))
-		if schemeResult[len(schemeResult)-1] == 'f' {
-			schemeResult = schemeResult[:len(schemeResult)-1]
-		}
-	} else {
-		schemeResult = hex.EncodeToString(decryptPlainText)
-	}
-
+	schemeResult := calcSchemeResult(decryptPlainText, supiType)
 	return schemeResult, nil
 }
 
@@ -284,17 +287,7 @@ func profileB(input, supiType string) (string, error) {
 	}
 
 	decryptPlainText := Aes128ctr(decryptCipherText, decryptEncKey, decryptIcb)
-
-	var schemeResult string
-	if supiType == typeIMSI {
-		schemeResult = hex.EncodeToString(swapNibbles(decryptPlainText))
-		if schemeResult[len(schemeResult)-1] == 'f' {
-			schemeResult = schemeResult[:len(schemeResult)-1]
-		}
-	} else {
-		schemeResult = hex.EncodeToString(decryptPlainText)
-	}
-
+	schemeResult := calcSchemeResult(decryptPlainText, supiType)
 	return schemeResult, nil
 }
 

--- a/suci/toSupi.go
+++ b/suci/toSupi.go
@@ -15,6 +15,7 @@ import (
 	"log"
 	"math"
 	"math/big"
+	"math/bits"
 	"strings"
 
 	"golang.org/x/crypto/curve25519"
@@ -128,7 +129,15 @@ func AnsiX963KDF(sharedKey, publicKey []byte, profileEncKeyLen, profileMacKeyLen
 	return kdfKey
 }
 
-func profileA(input string) (string, error) {
+func swapNibbles(input []byte) []byte {
+	output := make([]byte, len(input))
+	for i, b := range input {
+		output[i] = bits.RotateLeft8(b, 4)
+	}
+	return output
+}
+
+func profileA(input, supiType string) (string, error) {
 	logger.UeauLog.Infoln("SuciToSupi Profile A")
 	s, hexDecodeErr := hex.DecodeString(input)
 	if hexDecodeErr != nil {
@@ -182,10 +191,20 @@ func profileA(input string) (string, error) {
 
 	decryptPlainText := Aes128ctr(decryptCipherText, decryptEncKey, decryptIcb)
 
-	return hex.EncodeToString(decryptPlainText), nil
+	var schemeResult string
+	if supiType == typeIMSI {
+		schemeResult = hex.EncodeToString(swapNibbles(decryptPlainText))
+		if schemeResult[len(schemeResult)-1] == 'f' {
+			schemeResult = schemeResult[:len(schemeResult)-1]
+		}
+	} else {
+		schemeResult = hex.EncodeToString(decryptPlainText)
+	}
+
+	return schemeResult, nil
 }
 
-func profileB(input string) (string, error) {
+func profileB(input, supiType string) (string, error) {
 	logger.UeauLog.Infoln("SuciToSupi Profile B")
 	s, hexDecodeErr := hex.DecodeString(input)
 	if hexDecodeErr != nil {
@@ -266,7 +285,17 @@ func profileB(input string) (string, error) {
 
 	decryptPlainText := Aes128ctr(decryptCipherText, decryptEncKey, decryptIcb)
 
-	return hex.EncodeToString(decryptPlainText), nil
+	var schemeResult string
+	if supiType == typeIMSI {
+		schemeResult = hex.EncodeToString(swapNibbles(decryptPlainText))
+		if schemeResult[len(schemeResult)-1] == 'f' {
+			schemeResult = schemeResult[:len(schemeResult)-1]
+		}
+	} else {
+		schemeResult = hex.EncodeToString(decryptPlainText)
+	}
+
+	return schemeResult, nil
 }
 
 // suci-0(SUPI type)-mcc-mnc-routingIndentifier-protectionScheme-homeNetworkPublicKeyIdentifier-schemeOutput.
@@ -311,14 +340,14 @@ func ToSupi(suci string) (string, error) {
 	}
 
 	if scheme == profileAScheme {
-		profileAResult, err := profileA(suciPart[len(suciPart)-1])
+		profileAResult, err := profileA(suciPart[len(suciPart)-1], suciPart[supiTypePlace])
 		if err != nil {
 			return "", err
 		} else {
 			return supiPrefix + mccMnc + profileAResult, nil
 		}
 	} else if scheme == profileBScheme {
-		profileBResult, err := profileB(suciPart[len(suciPart)-1])
+		profileBResult, err := profileB(suciPart[len(suciPart)-1], suciPart[supiTypePlace])
 		if err != nil {
 			return "", err
 		} else {


### PR DESCRIPTION
The protection scheme output of the SUCI is the cipher text of **nibble swapped MSIN** when profile \<A> or profile \<B> is used as the protection scheme. After the decryption, the scheme output  need to be swapped. 

This fix change
- `supi conversion => imsi-460002143658709`
to
- `supi conversion => imsi-460001234567890`.

in
`INFO[2020-08-31T16:10:40+09:00]/src/udm/producer/generate_auth_data.go:35 free5gc/src/udm/producer.HandleGenerateAuthData() supi conversion => imsi-XXXXXXXXXX UDM=UEAU`
when the UE simulator registers to the Free5GC with config `imsi-460001234567890` and `profile <A/B>`.


<details><summary>logs</summary><div>

### before
```
DEBU[2020-08-31T16:10:40+09:00]/src/amf/gmm/handler.go:549 free5gc/src/amf/gmm.HandleRegistrationRequest() RegistrationType: Initial Registration        AMF=Gmm
DEBU[2020-08-31T16:10:40+09:00]/src/amf/gmm/handler.go:573 free5gc/src/amf/gmm.HandleRegistrationRequest() SUCI: suci-0-460-00-0-1-0-61d041dffd21c9b85c38a623e9e8c8951c28a5a32029978b824f39d5
7fb68f51ab0fb7d9a708cf1883c1f8f81c  AMF=Gmm
INFO[2020-08-31T16:10:40+09:00]/src/amf/gmm/handler.go:630 free5gc/src/amf/gmm.HandleRegistrationRequest() ue.Capability5GMM is nil in InitialUEMEssage  AMF=Gmm
TRAC[2020-08-31T16:10:40+09:00]/src/amf/gmm/sm.go:72 free5gc/src/amf/gmm.register_event_3gpp() amfUe.RegistrationType5GS
1                   AMF=Gmm
INFO[2020-08-31T16:10:40+09:00]/src/amf/gmm/handler.go:1644 free5gc/src/amf/gmm.startAuthenticationProcedure() Start authentication procedure                AMF=Gmm
2020/08/31 16:10:40 map[$and:[map[nfType:AUSF] map[$or:[map[allowedNfTypes:AMF] map[allowedNfTypes:map[$exists:false]]]]]]
[GIN] 2020/08/31 - 16:10:40 | 200 |   34.796173ms |       127.0.0.1 | GET      /nnrf-disc/v1/nf-instances?requester-nf-type=AMF&target-nf-type=AUSF
INFO[2020-08-31T16:10:40+09:00]/src/ausf/producer/ue_authentication.go:64 free5gc/src/ausf/producer.HandleUeAuthPostRequest() HandleUeAuthPostRequest                       AUSF=UeAuthPost
INFO[2020-08-31T16:10:40+09:00]/src/ausf/producer/ue_authentication.go:96 free5gc/src/ausf/producer.UeAuthPostRequestProcedure() Serving network authorized                    AUSF=UeAuthPos
t
2020/08/31 16:10:40 map[$and:[map[nfType:UDM] map[$or:[map[allowedNfTypes:AUSF] map[allowedNfTypes:map[$exists:false]]]] map[nfServices:map[$elemMatch:map[nfServiceStatus:REGISTERED service
Name:map[$in:[nudm-ueau]]]]]]]
[GIN] 2020/08/31 - 16:10:40 | 200 |   95.563402ms |       127.0.0.1 | GET      /nnrf-disc/v1/nf-instances?requester-nf-type=AUSF&service-names=nudm-ueau&target-nf-type=UDM
INFO[2020-08-31T16:10:40+09:00]/lib/util_3gpp/suci/toSupi.go:260 free5gc/lib/util_3gpp/suci.ToSupi() suciPart [suci 0 460 00 0 1 0 61d041dffd21c9b85c38a623e9e8c8951c28a5a32029978b824f39d57f
b68f51ab0fb7d9a708cf1883c1f8f81c]  UDM=UEAU
INFO[2020-08-31T16:10:40+09:00]/lib/util_3gpp/suci/toSupi.go:278 free5gc/lib/util_3gpp/suci.ToSupi() scheme 1                                      UDM=UEAU
INFO[2020-08-31T16:10:40+09:00]/lib/util_3gpp/suci/toSupi.go:285 free5gc/lib/util_3gpp/suci.ToSupi() SUPI type is IMSI                             UDM=UEAU
INFO[2020-08-31T16:10:40+09:00]/lib/util_3gpp/suci/toSupi.go:125 free5gc/lib/util_3gpp/suci.profileA() SuciToSupi Profile A                          UDM=UEAU
INFO[2020-08-31T16:10:40+09:00]/lib/util_3gpp/suci/toSupi.go:159 free5gc/lib/util_3gpp/suci.profileA() decryption MAC match                          UDM=UEAU
INFO[2020-08-31T16:10:40+09:00]/src/udm/producer/generate_auth_data.go:35 free5gc/src/udm/producer.HandleGenerateAuthData() supi conversion => imsi-460000021020000       UDM=UEAU
http://127.0.0.1:29510
2020/08/31 16:10:40 map[$and:[map[nfType:UDR] map[$or:[map[allowedNfTypes:UDM] map[allowedNfTypes:map[$exists:false]]]]]]
[GIN] 2020/08/31 - 16:10:40 | 200 |   33.479546ms |       127.0.0.1 | GET      /nnrf-disc/v1/nf-instances?requester-nf-type=UDM&target-nf-type=UDR
[GIN] 2020/08/31 - 16:10:40 | 404 |    1.101564ms |       127.0.0.1 | GET      /nudr-dr/v1/subscription-data/imsi-460000021020000/authentication-data/authentication-subscription
ERRO[2020-08-31T16:10:40+09:00]/src/udm/producer/generate_auth_data.go:40 free5gc/src/udm/producer.HandleGenerateAuthData() Return from UDR QueryAuthSubsData error       UDM=UEAU
[GIN] 2020/08/31 - 16:10:40 | 403 |   43.826527ms |       127.0.0.1 | POST     /nudm-ueau/v1/suci-0-460-00-0-1-0-61d041dffd21c9b85c38a623e9e8c8951c28a5a32029978b824f39d57fb68f51ab0fb7d9a708
cf1883c1f8f81c/security-information/generate-auth-data
INFO[2020-08-31T16:10:40+09:00]/src/ausf/producer/ue_authentication.go:107 free5gc/src/ausf/producer.UeAuthPostRequestProcedure() 403 Forbidden                                 AUSF=UeAuthPo
st
[GIN] 2020/08/31 - 16:10:40 | 200 |  148.608178ms |       127.0.0.1 | POST     /nausf-auth/v1/ue-authentications
ERRO[2020-08-31T16:10:40+09:00]/src/amf/nas/handler.go:42 free5gc/src/amf/nas.HandleNAS() Handle NAS Error: 200 is not a valid status code in UeAuthenticationsPost  AMF=NGAP
```

### fixed
```
INFO[2020-09-03T14:27:34+09:00]/src/amf/gmm/handler.go:528 free5gc/src/amf/gmm.HandleRegistrationRequest() [AMF] Handle Registration Request             AMF=Gmm
DEBU[2020-09-03T14:27:34+09:00]/src/amf/gmm/handler.go:549 free5gc/src/amf/gmm.HandleRegistrationRequest() RegistrationType: Initial Registration        AMF=Gmm
DEBU[2020-09-03T14:27:34+09:00]/src/amf/gmm/handler.go:573 free5gc/src/amf/gmm.HandleRegistrationRequest() SUCI: suci-0-460-00-0-1-0-028edecea682c097f8ddac193fdeb923538688d2e9333f5cdfa0a9be64f4e662c5a79508e6897769bda9640424  AMF=Gmm
INFO[2020-09-03T14:27:34+09:00]/src/amf/gmm/handler.go:630 free5gc/src/amf/gmm.HandleRegistrationRequest() ue.Capability5GMM is nil in InitialUEMEssage  AMF=Gmm
TRAC[2020-09-03T14:27:34+09:00]/src/amf/gmm/sm.go:72 free5gc/src/amf/gmm.register_event_3gpp() amfUe.RegistrationType5GS
1                   AMF=Gmm
INFO[2020-09-03T14:27:34+09:00]/src/amf/gmm/handler.go:1644 free5gc/src/amf/gmm.startAuthenticationProcedure() Start authentication procedure                AMF=Gmm
2020/09/03 14:27:34 map[$and:[map[nfType:AUSF] map[$or:[map[allowedNfTypes:AMF] map[allowedNfTypes:map[$exists:false]]]]]]
[GIN] 2020/09/03 - 14:27:34 | 200 |   46.875416ms |       127.0.0.1 | GET      /nnrf-disc/v1/nf-instances?requester-nf-type=AMF&target-nf-type=AUSF
INFO[2020-09-03T14:27:34+09:00]/src/ausf/producer/ue_authentication.go:64 free5gc/src/ausf/producer.HandleUeAuthPostRequest() HandleUeAuthPostRequest                       AUSF=UeAuthPost
INFO[2020-09-03T14:27:34+09:00]/src/ausf/producer/ue_authentication.go:96 free5gc/src/ausf/producer.UeAuthPostRequestProcedure() Serving network authorized                    AUSF=UeAuthPost
2020/09/03 14:27:34 map[$and:[map[nfType:UDM] map[$or:[map[allowedNfTypes:AUSF] map[allowedNfTypes:map[$exists:false]]]] map[nfServices:map[$elemMatch:map[nfServiceStatus:REGISTERED serviceName:map[$in:[nudm-ueau]]]]]]]
[GIN] 2020/09/03 - 14:27:34 | 200 |  105.887844ms |       127.0.0.1 | GET      /nnrf-disc/v1/nf-instances?requester-nf-type=AUSF&service-names=nudm-ueau&target-nf-type=UDM
INFO[2020-09-03T14:27:34+09:00]/lib/util_3gpp/suci/toSupi.go:289 free5gc/lib/util_3gpp/suci.ToSupi() suciPart [suci 0 460 00 0 1 0 028edecea682c097f8ddac193fdeb923538688d2e9333f5cdfa0a9be64f4e662c5a79508e6897769bda9640424]  UDM=UEAU
INFO[2020-09-03T14:27:34+09:00]/lib/util_3gpp/suci/toSupi.go:307 free5gc/lib/util_3gpp/suci.ToSupi() scheme 1                                      UDM=UEAU
INFO[2020-09-03T14:27:34+09:00]/lib/util_3gpp/suci/toSupi.go:314 free5gc/lib/util_3gpp/suci.ToSupi() SUPI type is IMSI                             UDM=UEAU
INFO[2020-09-03T14:27:34+09:00]/lib/util_3gpp/suci/toSupi.go:134 free5gc/lib/util_3gpp/suci.profileA() SuciToSupi Profile A                          UDM=UEAU
INFO[2020-09-03T14:27:34+09:00]/lib/util_3gpp/suci/toSupi.go:168 free5gc/lib/util_3gpp/suci.profileA() decryption MAC match                          UDM=UEAU
INFO[2020-09-03T14:27:34+09:00]/src/udm/producer/generate_auth_data.go:35 free5gc/src/udm/producer.HandleGenerateAuthData() supi conversion => imsi-460000012200000       UDM=UEAU
http://127.0.0.1:29510
2020/09/03 14:27:34 map[$and:[map[nfType:UDR] map[$or:[map[allowedNfTypes:UDM] map[allowedNfTypes:map[$exists:false]]]]]]
[GIN] 2020/09/03 - 14:27:34 | 200 |   37.497316ms |       127.0.0.1 | GET      /nnrf-disc/v1/nf-instances?requester-nf-type=UDM&target-nf-type=UDR
[GIN] 2020/09/03 - 14:27:34 | 200 |    1.271238ms |       127.0.0.1 | GET      /nudr-dr/v1/subscription-data/imsi-460000012200000/authentication-data/authentication-subscription
ERRO[2020-09-03T14:27:34+09:00]/src/udm/producer/generate_auth_data.go:81 free5gc/src/udm/producer.HandleGenerateAuthData() OP_str length is  0                           UDM=UEAU
[GIN] 2020/09/03 - 14:27:34 | 200 |   49.119849ms |       127.0.0.1 | POST     /nudm-ueau/v1/suci-0-460-00-0-1-0-028edecea682c097f8ddac193fdeb923538688d2e9333f5cdfa0a9be64f4e662c5a79508e6897769bda9640424/security-information/generate-auth-data
INFO[2020-09-03T14:27:34+09:00]/src/ausf/producer/ue_authentication.go:124 free5gc/src/ausf/producer.UeAuthPostRequestProcedure() Add SuciSupiPair (suci-0-460-00-0-1-0-028edecea682c097f8ddac193fdeb923538688d2e9333f5cdfa0a9be64f4e662c5a79508e6897769bda9640424, imsi-460000012200000) to map.  AUSF=UeAuthPost
INFO[2020-09-03T14:27:34+09:00]/src/ausf/producer/ue_authentication.go:130 free5gc/src/ausf/producer.UeAuthPostRequestProcedure() Use 5G AKA auth method                        AUSF=UeAuthPost
INFO[2020-09-03T14:27:34+09:00]/src/ausf/producer/ue_authentication.go:138 free5gc/src/ausf/producer.UeAuthPostRequestProcedure() XresStar = 6132323037336465373762366137303635656462383530346434633834373666  AUSF=5gAkaComfirm
[GIN] 2020/09/03 - 14:27:34 | 201 |  177.846174ms |       127.0.0.1 | POST     /nausf-auth/v1/ue-authentications
INFO[2020-09-03T14:27:34+09:00]/src/amf/gmm/message/send.go:65 free5gc/src/amf/gmm/message.SendAuthenticationRequest() [NAS] Send Authentication Request[Retry: 0]   AMF=Gmm
INFO[2020-09-03T14:27:34+09:00]/src/amf/ngap/message/send.go:138 free5gc/src/amf/ngap/message.SendDownlinkNasTransport() [AMF] Send Downlink Nas Transport             AMF=NGAP
DEBU[2020-09-03T14:27:34+09:00]/src/amf/ngap/message/send.go:32 free5gc/src/amf/ngap/message.SendToRan() [NGAP] Send To Ran [IP: 172.17.1.230:38412]   AMF=NGAP
DEBU[2020-09-03T14:27:34+09:00]/src/amf/ngap/sctp/sctp.go:100 free5gc/src/amf/ngap/sctp.(*SCTPListener).forwardData() Packet get: 0x002e403f000004000a0002000100550005c0bc00000000260016157e00572d10a22073de77b6a7065edb8504d4c8476f0079400f4064f000000000001064f000000001  AMF=NGAP
INFO[2020-09-03T14:27:34+09:00]/src/amf/ngap/handler.go:180 free5gc/src/amf/ngap.HandleUplinkNasTransport() [AMF] Uplink Nas Transport                    AMF=NGAP
TRAC[2020-09-03T14:27:34+09:00]/src/amf/ngap/handler.go:187 free5gc/src/amf/ngap.HandleUplinkNasTransport() [NGAP] Decode IE AmfUeNgapID                  AMF=NGAP
TRAC[2020-09-03T14:27:34+09:00]/src/amf/ngap/handler.go:194 free5gc/src/amf/ngap.HandleUplinkNasTransport() [NGAP] Decode IE RanUeNgapID                  AMF=NGAP
TRAC[2020-09-03T14:27:34+09:00]/src/amf/ngap/handler.go:201 free5gc/src/amf/ngap.HandleUplinkNasTransport() [NGAP] Decode IE NasPdu                       AMF=NGAP
TRAC[2020-09-03T14:27:34+09:00]/src/amf/ngap/handler.go:208 free5gc/src/amf/ngap.HandleUplinkNasTransport() [NGAP] Decode IE UserLocationInformation      AMF=NGAP
TRAC[2020-09-03T14:27:34+09:00]/src/amf/ngap/handler.go:4142 free5gc/src/amf/ngap.printRanInfo() IP[172.17.1.230:38412] GNbId[00000000]        AMF=NGAP
TRAC[2020-09-03T14:27:34+09:00]/src/amf/ngap/handler.go:233 free5gc/src/amf/ngap.HandleUplinkNasTransport() RANUENGAPID[3154116608] AMFUENGAPID[1]        AMF=NGAP
TRAC[2020-09-03T14:27:34+09:00]/src/amf/nas/nas_security/security.go:90 free5gc/src/amf/nas/nas_security.Decode() securityHeaderType is  0                      AMF=NAS
INFO[2020-09-03T14:27:34+09:00]/src/amf/gmm/handler.go:1957 free5gc/src/amf/gmm.HandleAuthenticationResponse() [AMF] Handle Authentication Response          AMF=Gmm
INFO[2020-09-03T14:27:34+09:00]/src/ausf/producer/ue_authentication.go:46 free5gc/src/ausf/producer.HandleAuth5gAkaComfirmRequest() Auth5gAkaComfirmRequest                       AUSF=5gAkaComfirm
INFO[2020-09-03T14:27:34+09:00]/src/ausf/producer/ue_authentication.go:241 free5gc/src/ausf/producer.Auth5gAkaComfirmRequestProcedure() res*: 6132323037336465373762366137303635656462383530346434633834373666
Xres*: 6132323037336465373762366137303635656462383530346434633834373666  AUSF=5gAkaComfirm
INFO[2020-09-03T14:27:34+09:00]/src/ausf/producer/ue_authentication.go:246 free5gc/src/ausf/producer.Auth5gAkaComfirmRequestProcedure() 5G AKA confirmation succeeded                 AUSF=5gAkaComfirm
[GIN] 2020/09/03 - 14:27:34 | 204 |    1.157997ms |       127.0.0.1 | PUT      /nudr-dr/v1/subscription-data/imsi-460000012200000/authentication-data/authentication-status
[GIN] 2020/09/03 - 14:27:34 | 201 |    2.007783ms |       127.0.0.1 | POST     /nudm-ueau/v1/imsi-460000012200000/auth-events
[GIN] 2020/09/03 - 14:27:34 | 200 |    3.022306ms |       127.0.0.1 | PUT      /nausf-auth/v1/ue-authentications/suci-0-460-00-0-1-0-028edecea682c097f8ddac193fdeb923538688d2e9333f5cdfa0a9be64f4e662c5a79508e6897769bda9640424/5g-aka-confirmation
DEBU[2020-09-03T14:27:34+09:00]/src/amf/gmm/handler.go:2006 free5gc/src/amf/gmm.HandleAuthenticationResponse() ue.DerivateKamf() 9aad06518598ad4a8216f8e97302c19c67e6131bb052dca2b67ba5a9c341da95  AMF=Gmm
INFO[2020-09-03T14:27:34+09:00]/src/amf/gmm/message/send.go:165 free5gc/src/amf/gmm/message.SendSecurityModeCommand() [NAS] Send Security Mode Command              AMF=Gmm
```
</div></details>


See 3GPP TS33.501 C.4.3 ECIES Profile A.
```
The following test data set corresponds to SUCI computation in the UE for IMSI-based SUPI and ECIES Profile A. 
IMSI consists of MCC|MNC: '274012' and MSIN: '001002086'

ECIES test data
Plaintext block:
'00012080f6'
```

I used below code as reference.
https://github.com/free5gc/nas/blob/963590d1cdbe825b42d2db18b4dbd4fc19b0e793/nasConvert/MobileIdentity5GS.go#L65-L78